### PR TITLE
avoid defaultLineWidth; tuples instead of lists; Show Guides on after adding one

### DIFF
--- a/StemThickness.glyphsReporter/Contents/Info.plist
+++ b/StemThickness.glyphsReporter/Contents/Info.plist
@@ -17,15 +17,15 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleVersion</key>
-	<string>23</string>
+	<string>24</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.1</string>
+	<string>1.2.2</string>
 	<key>UpdateFeedURL</key>
 	<string>https://raw.githubusercontent.com/RafalBuchner/StemThickness/master/StemThickness.glyphsReporter/Contents/Info.plist</string>
 	<key>productPageURL</key>
 	<string>https://github.com/RafalBuchner/StemThickness</string>
 	<key>productReleaseNotes</key>
-	<string>New: context menu item for converting measurement into a guide (thx @mekkablue)</string>
+	<string>Fix #21: avoid default line width</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright, Rafał Buchner, 2016</string>
 	<key>NSPrincipalClass</key>

--- a/StemThickness.glyphsReporter/Contents/Resources/plugin.py
+++ b/StemThickness.glyphsReporter/Contents/Resources/plugin.py
@@ -382,6 +382,9 @@ class StemThickness(ReporterPlugin):
             newGuide.angle = math.degrees(guideAngle)
             newGuide.setShowMeasurement_(True)
             currentLayer.guides.append(newGuide)
+            
+            # make sure Show Guides is enabled:
+            Glyphs.defaults["showGuidelines"] = 1
         except Exception as e:
             print e
             import traceback

--- a/StemThickness.glyphsReporter/Contents/Resources/plugin.py
+++ b/StemThickness.glyphsReporter/Contents/Resources/plugin.py
@@ -179,10 +179,10 @@ class StemThickness(ReporterPlugin):
         SecondDistance = distance( closestData['onCurve'], FirstCrossPointB )
 
         # drawsLine between points on curve
-        NSBezierPath.setDefaultLineWidth_( 1.0 / scale )
+        # NSBezierPath.setDefaultLineWidth_( 1.0 / scale )
 
         firstDraws  = False
-        red  =  (0.96, 0.44, 0.44, 1)
+        red  = ( 0.96, 0.44, 0.44, 1 )
         blue = ( 0.65, 0.63, 0.94, 1 )
         if FirstDistance < 1199:
             firstDraws = True
@@ -200,7 +200,7 @@ class StemThickness(ReporterPlugin):
         myPointsSize = HandleSize - HandleSize / 8
         zoomedMyPoints = myPointsSize / scale
         distanceShowed = formatDistance(d,scale)
-        thisDistanceCenter = pathAB(0.5, [onCurve.x, cross.x],[onCurve.y, cross.y] )
+        thisDistanceCenter = pathAB( 0.5, (onCurve.x, cross.x), (onCurve.y, cross.y) )
         NSColor.colorWithCalibratedRed_green_blue_alpha_( *color ).set()
         self.drawDashedStrokeAB( onCurve, cross )
         self.drawRoundedRectangleForStringAtPosition(" %s " % distanceShowed, (thisDistanceCenter.x, thisDistanceCenter.y), 8, color = color)
@@ -241,7 +241,7 @@ class StemThickness(ReporterPlugin):
     def drawDashedStrokeAB(self,A,B):
         bez = NSBezierPath.bezierPath()
         bez.setLineWidth_(0)
-        bez.setLineDash_count_phase_([2.0,2.0], 2,0)
+        bez.setLineDash_count_phase_( (2.0,2.0), 2,0)
         bez.moveToPoint_(A)
         bez.lineToPoint_(B)
         bez.stroke()
@@ -318,9 +318,11 @@ class StemThickness(ReporterPlugin):
         panel.size = NSSize( width, scaledSize + rim*2 )
         NSColor.colorWithCalibratedRed_green_blue_alpha_( 1,1,1,1 ).set()
         # NSColor.colorWithCalibratedRed_green_blue_alpha_( *color ).set() # ORGINAL
-        NSBezierPath.bezierPathWithRoundedRect_xRadius_yRadius_( panel, scaledSize*0.5, scaledSize*0.5 ).fill()
+        roundedRect = NSBezierPath.bezierPathWithRoundedRect_xRadius_yRadius_( panel, scaledSize*0.5, scaledSize*0.5 )
+        roundedRect.fill()
         NSColor.colorWithCalibratedRed_green_blue_alpha_( 0,0,0,0.1 ).set()
-        NSBezierPath.bezierPathWithRoundedRect_xRadius_yRadius_( panel, scaledSize*0.5, scaledSize*0.5 ).stroke()
+        roundedRect.setLineWidth_( 1.0/self.getScale() )
+        roundedRect.stroke()
         self.drawTextAtPoint(thisString, center, fontsize, align="center" )
 
     def drawTextAtPoint(self, text, textPosition, fontSize=10.0, fontColor=NSColor.blackColor(), align='center'):


### PR DESCRIPTION
1. Setting defaultLineWidth is not a good idea as it may mess up subsequent drawing in the canvas.
2. tuples need less memory than lists and are quicker
3. Show Guides should be on after adding a guide through the context menu to avoid user confusion